### PR TITLE
Add sr-Latn language

### DIFF
--- a/languages.js
+++ b/languages.js
@@ -88,6 +88,7 @@ var langs = {
     'sm': 'Samoan',
     'gd': 'Scots Gaelic',
     'sr': 'Serbian',
+    'sr-Latn': 'Serbian Latin',
     'st': 'Sesotho',
     'sn': 'Shona',
     'sd': 'Sindhi',


### PR DESCRIPTION
Serbian Latin is more used than the Cyrillic alphabet in Serbia.